### PR TITLE
Add import_postings command for JobTech postings

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ python backend/manage.py createsuperuser
 python backend/manage.py runserver
 ```
 
+Optionally fill the database with real postings from Arbetsförmedlingen's
+open [JobTech API](https://jobsearch.api.jobtechdev.se):
+
+```bash
+python backend/manage.py import_postings --query "python" --limit 50
+```
+
 Then open:
 
 - Swagger UI: <http://127.0.0.1:8000/api/docs/>

--- a/backend/core/management/commands/import_postings.py
+++ b/backend/core/management/commands/import_postings.py
@@ -1,0 +1,81 @@
+"""Import job postings from Arbetsförmedlingen's open JobTech Search API.
+
+https://jobsearch.api.jobtechdev.se — public, no API key required.
+Postings are upserted on (source="jobtech", external_id), so re-running
+the command refreshes existing rows instead of duplicating them.
+"""
+
+import requests
+from django.core.management.base import BaseCommand, CommandError
+
+from core.models import JobPosting, Organization
+
+JOBTECH_SEARCH_URL = "https://jobsearch.api.jobtechdev.se/search"
+IMPORT_ORG_NAME = "Arbetsförmedlingen (import)"
+MAX_LIMIT = 100
+
+
+def to_posting_fields(hit: dict) -> dict:
+    """Map a JobTech search hit to JobPosting fields."""
+    employer = (hit.get("employer") or {}).get("name") or ""
+    workplace = hit.get("workplace_address") or {}
+    publication_date = (hit.get("publication_date") or "")[:10]
+    return {
+        "title": hit.get("headline") or "",
+        "company_name": employer,
+        "location": workplace.get("municipality") or "",
+        "published_at": publication_date or None,
+    }
+
+
+class Command(BaseCommand):
+    help = "Import job postings from Arbetsförmedlingen's JobTech Search API."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--query", default="", help="Free text search query.")
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=20,
+            help=f"Max postings to import (<= {MAX_LIMIT}).",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            response = requests.get(
+                JOBTECH_SEARCH_URL,
+                params={
+                    "q": options["query"],
+                    "limit": min(options["limit"], MAX_LIMIT),
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise CommandError(f"JobTech request failed: {exc}") from exc
+
+        hits = response.json().get("hits", [])
+        organization, _ = Organization.objects.get_or_create(name=IMPORT_ORG_NAME)
+
+        created = updated = skipped = 0
+        for hit in hits:
+            external_id = str(hit.get("id") or "")
+            fields = to_posting_fields(hit)
+            if not external_id or not fields["title"]:
+                skipped += 1
+                continue
+            _, was_created = JobPosting.objects.update_or_create(
+                source="jobtech",
+                external_id=external_id,
+                defaults={"organization": organization, **fields},
+            )
+            if was_created:
+                created += 1
+            else:
+                updated += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Imported {created} new, updated {updated}, skipped {skipped}."
+            )
+        )

--- a/backend/core/tests/test_import_postings.py
+++ b/backend/core/tests/test_import_postings.py
@@ -1,0 +1,94 @@
+from io import StringIO
+
+import pytest
+from core.management.commands import import_postings
+from core.models import JobPosting, Organization
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db
+
+SAMPLE_HITS = [
+    {
+        "id": "29000001",
+        "headline": "Backend Developer",
+        "employer": {"name": "Acme AB"},
+        "workplace_address": {"municipality": "Stockholm"},
+        "publication_date": "2026-06-01T08:00:00",
+    },
+    {
+        "id": "29000002",
+        "headline": "Data Engineer",
+        "employer": None,
+        "workplace_address": None,
+        "publication_date": None,
+    },
+    {
+        # Missing headline -> skipped
+        "id": "29000003",
+        "headline": "",
+    },
+]
+
+
+class FakeResponse:
+    def __init__(self, hits):
+        self._hits = hits
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"hits": self._hits}
+
+
+@pytest.fixture
+def mock_jobtech(monkeypatch):
+    calls = []
+
+    def fake_get(url, params=None, timeout=None):
+        calls.append({"url": url, "params": params})
+        return FakeResponse(SAMPLE_HITS)
+
+    monkeypatch.setattr(import_postings.requests, "get", fake_get)
+    return calls
+
+
+def test_to_posting_fields_maps_hit():
+    fields = import_postings.to_posting_fields(SAMPLE_HITS[0])
+    assert fields == {
+        "title": "Backend Developer",
+        "company_name": "Acme AB",
+        "location": "Stockholm",
+        "published_at": "2026-06-01",
+    }
+
+
+def test_to_posting_fields_handles_missing_data():
+    fields = import_postings.to_posting_fields(SAMPLE_HITS[1])
+    assert fields == {
+        "title": "Data Engineer",
+        "company_name": "",
+        "location": "",
+        "published_at": None,
+    }
+
+
+def test_import_creates_postings_under_import_org(mock_jobtech):
+    out = StringIO()
+    call_command("import_postings", "--query", "python", stdout=out)
+
+    assert "Imported 2 new, updated 0, skipped 1." in out.getvalue()
+    org = Organization.objects.get(name=import_postings.IMPORT_ORG_NAME)
+    posting = JobPosting.objects.get(source="jobtech", external_id="29000001")
+    assert posting.organization == org
+    assert posting.title == "Backend Developer"
+    assert mock_jobtech[0]["params"]["q"] == "python"
+
+
+def test_import_is_idempotent(mock_jobtech):
+    call_command("import_postings", stdout=StringIO())
+    out = StringIO()
+    call_command("import_postings", stdout=out)
+
+    assert "Imported 0 new, updated 2, skipped 1." in out.getvalue()
+    assert JobPosting.objects.filter(source="jobtech").count() == 2

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -14,6 +14,8 @@
 - Auth provider (dj-rest-auth/allauth; BankID planned)
 - Audit log (append-only, in `core.AuditLog`)
 - Partner integration layer (API key auth; OAuth2/mTLS future)
+- Posting import from Arbetsförmedlingen's JobTech Search API
+  (`import_postings` management command, upserts on source+external_id)
 
 ## Data Flows (High level)
 


### PR DESCRIPTION
## Summary

Fills the platform with **real job ads** from Arbetsförmedlingen's open [JobTech Search API](https://jobsearch.api.jobtechdev.se) (public, no API key).

- `python backend/manage.py import_postings --query "python" --limit 50`
- Upserts on `(source="jobtech", external_id)` — the unique constraint added earlier was built for exactly this; re-runs refresh existing rows instead of duplicating
- Imported postings live under a dedicated "Arbetsförmedlingen (import)" organization
- Hits without id or headline are skipped and counted

## Tests

42 passing (4 new, fully mocked — no network in CI): field mapping, missing employer/address data, creation under the import org, and idempotency on re-run.

`ruff`, `black`, `pytest` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)