### PR TITLE
Make the project production-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
         env:
           PYTHONPATH: backend
           DJANGO_SETTINGS_MODULE: config.settings
+          # Import-time flag: keeps prod-only hardening (SSL redirect,
+          # manifest static storage) out of the test client's way.
+          DJANGO_DEBUG: "1"
           DB_ENGINE: django.db.backends.postgresql
           DB_NAME: afapi_test
           DB_USER: afapi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: afapi_test
+          POSTGRES_USER: afapi
+          POSTGRES_PASSWORD: afapi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U afapi"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,10 +43,16 @@ jobs:
       - name: Black (check)
         run: black --check .
 
-      - name: Pytest
+      - name: Pytest (against Postgres)
         env:
           PYTHONPATH: backend
           DJANGO_SETTINGS_MODULE: config.settings
+          DB_ENGINE: django.db.backends.postgresql
+          DB_NAME: afapi_test
+          DB_USER: afapi
+          DB_PASSWORD: afapi
+          DB_HOST: 127.0.0.1
+          DB_PORT: "5432"
         run: pytest
 
   frontend:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 # Django
 db.sqlite3
 .env
+backend/staticfiles/
 
 # Frontend
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: build the frontend
+FROM node:22-slim AS frontend
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-fund --no-audit
+COPY frontend/ ./
+RUN npm run build
+
+# Stage 2: the Django app, serving API + built frontend via WhiteNoise
+FROM python:3.13-slim
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app/backend \
+    DJANGO_SETTINGS_MODULE=config.settings
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/ backend/
+COPY --from=frontend /app/frontend/dist frontend/dist
+
+RUN python backend/manage.py collectstatic --no-input
+
+EXPOSE 8000
+CMD ["sh", "-c", "python backend/manage.py migrate --no-input && gunicorn config.wsgi:application --chdir backend --bind 0.0.0.0:${PORT:-8000} --workers 2"]

--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ identifiers beyond the queried person, no application status. Every call
 writes an `applications.disclosed_partner` audit entry. Partners can be
 deactivated in the admin; keys cannot be read back or recreated.
 
+## Deployment
+
+The repo is deploy-ready for [Render](https://render.com) (or any Docker
+host):
+
+- **One service serves everything**: the `Dockerfile` builds the frontend
+  (Node stage), collects static files, and gunicorn + WhiteNoise serve
+  the SPA at `/`, hashed assets, the API and the admin
+- **`render.yaml` blueprint**: web service + managed Postgres; secrets
+  (`DJANGO_SECRET_KEY`, `PERSON_HASH_KEY`) are generated, `DATABASE_URL`
+  is wired from the database. Deploy via Render → New → Blueprint
+- **Production hardening** activates when `DJANGO_DEBUG=0`: HSTS,
+  SSL redirect (behind proxy header), secure cookies, manifest static
+  storage, referrer policy
+- **Rate limiting**: mock BankID endpoints are throttled per IP
+  (`THROTTLE_BANKID`, default 10/min) and the partner API per client
+  (`THROTTLE_PARTNER`, default 120/min)
+- CI runs the backend tests against **Postgres 16** (same engine as
+  production) plus the frontend build
+
 ## Testing and linting
 
 ```bash

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -16,6 +16,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+import dj_database_url
 from dotenv import load_dotenv
 
 # Paths & Environment
@@ -61,6 +62,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -91,16 +93,21 @@ WSGI_APPLICATION = "config.wsgi.application"
 
 # Database-
 
-DATABASES = {
-    "default": {
-        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.sqlite3"),
-        "NAME": os.getenv("DB_NAME", BASE_DIR / "db.sqlite3"),
-        "USER": os.getenv("DB_USER", ""),
-        "PASSWORD": os.getenv("DB_PASSWORD", ""),
-        "HOST": os.getenv("DB_HOST", ""),
-        "PORT": os.getenv("DB_PORT", ""),
+DATABASE_URL = os.getenv("DATABASE_URL")
+if DATABASE_URL:
+    # Hosted environments (e.g. Render) provide a single URL.
+    DATABASES = {"default": dj_database_url.parse(DATABASE_URL, conn_max_age=600)}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.sqlite3"),
+            "NAME": os.getenv("DB_NAME", BASE_DIR / "db.sqlite3"),
+            "USER": os.getenv("DB_USER", ""),
+            "PASSWORD": os.getenv("DB_PASSWORD", ""),
+            "HOST": os.getenv("DB_HOST", ""),
+            "PORT": os.getenv("DB_PORT", ""),
+        }
     }
-}
 
 # Password validation
 
@@ -126,6 +133,42 @@ USE_TZ = True
 # Static files
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+# The built frontend (frontend/dist) is served by WhiteNoise at the site
+# root: index.html on "/", hashed assets under /assets/. Django routes
+# (admin, api, ...) take precedence via URL resolution order.
+FRONTEND_DIST = BASE_DIR.parent / "frontend" / "dist"
+if FRONTEND_DIST.exists():
+    WHITENOISE_ROOT = FRONTEND_DIST
+    WHITENOISE_INDEX_FILE = True
+
+if not DEBUG:
+    STORAGES = {
+        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+        },
+    }
+
+# Production security (active when DEBUG is off)
+
+if not DEBUG:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    SECURE_SSL_REDIRECT = os.getenv("DJANGO_SSL_REDIRECT", "1") == "1"
+    if SECURE_SSL_REDIRECT:
+        SECURE_HSTS_SECONDS = 31536000
+        SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+        SECURE_HSTS_PRELOAD = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_REFERRER_POLICY = "same-origin"
+
+CSRF_TRUSTED_ORIGINS = [
+    origin
+    for origin in os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").split(",")
+    if origin
+]
 
 # Default primary key field type
 
@@ -141,6 +184,10 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 20,
+    "DEFAULT_THROTTLE_RATES": {
+        "bankid": os.getenv("THROTTLE_BANKID", "10/min"),
+        "partner": os.getenv("THROTTLE_PARTNER", "120/min"),
+    },
 }
 
 SPECTACULAR_SETTINGS = {

--- a/backend/core/bankid.py
+++ b/backend/core/bankid.py
@@ -15,6 +15,7 @@ from rest_framework.decorators import (
     api_view,
     authentication_classes,
     permission_classes,
+    throttle_classes,
 )
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -23,6 +24,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from .audit import log_event
 from .identity import normalize_personal_number, pseudonymize_personal_number
 from .models import ApplicantProfile, AuditLog
+from .throttling import BankIDRateThrottle
 
 User = get_user_model()
 
@@ -70,6 +72,7 @@ def _mock_disabled_response():
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
+@throttle_classes([BankIDRateThrottle])
 def bankid_initiate(request):
     """Start a mock BankID order; returns an order_ref for collect."""
     unavailable = _mock_disabled_response()
@@ -101,6 +104,7 @@ def bankid_initiate(request):
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
+@throttle_classes([BankIDRateThrottle])
 def bankid_collect(request):
     """Complete a mock BankID order: link the identity and issue JWT."""
     unavailable = _mock_disabled_response()

--- a/backend/core/tests/conftest.py
+++ b/backend/core/tests/conftest.py
@@ -1,9 +1,17 @@
 import pytest
 from core.models import EmployerProfile, JobPosting, Organization
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from rest_framework.test import APIClient
 
 User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    # Throttle counters live in the cache; keep tests independent.
+    cache.clear()
+    yield
 
 
 @pytest.fixture

--- a/backend/core/tests/test_throttling.py
+++ b/backend/core/tests/test_throttling.py
@@ -1,0 +1,18 @@
+import pytest
+from core.throttling import BankIDRateThrottle
+
+pytestmark = pytest.mark.django_db
+
+INITIATE = "/api/v1/auth/bankid/initiate/"
+
+
+def test_bankid_initiate_is_throttled(api_client, settings, monkeypatch):
+    settings.BANKID_MOCK = True
+    monkeypatch.setattr(BankIDRateThrottle, "rate", "3/min", raising=False)
+
+    for _ in range(3):
+        response = api_client.post(INITIATE, {"personal_number": "19900101-2384"})
+        assert response.status_code == 200
+
+    blocked = api_client.post(INITIATE, {"personal_number": "19900101-2384"})
+    assert blocked.status_code == 429

--- a/backend/core/throttling.py
+++ b/backend/core/throttling.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle
+
+
+class BankIDRateThrottle(AnonRateThrottle):
+    """Per-IP limit on the mock BankID endpoints."""
+
+    scope = "bankid"
+
+
+class PartnerRateThrottle(SimpleRateThrottle):
+    """Per-partner-client limit on the partner API."""
+
+    scope = "partner"
+
+    def get_cache_key(self, request, view):
+        client = getattr(request, "auth", None)
+        ident = getattr(client, "id", None) or self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import (
     api_view,
     authentication_classes,
     permission_classes,
+    throttle_classes,
 )
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -24,6 +25,7 @@ from .serializers import (
     PartnerApplicationEventSerializer,
     ProfileSerializer,
 )
+from .throttling import PartnerRateThrottle
 
 
 @extend_schema(
@@ -214,6 +216,7 @@ class EmployerApplicationsView(generics.ListAPIView):
 @api_view(["GET"])
 @authentication_classes([PartnerAPIKeyAuthentication])
 @permission_classes([IsPartner])
+@throttle_classes([PartnerRateThrottle])
 def partner_application_events(request):
     """Disclose application events for one person and time period.
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+# Render blueprint: web service (Docker) + managed Postgres.
+# Deploy: push to GitHub -> render.com -> New + Blueprint -> select repo.
+services:
+  - type: web
+    name: af-jobbansokan
+    runtime: docker
+    plan: free
+    healthCheckPath: /health/
+    envVars:
+      - key: DJANGO_SECRET_KEY
+        generateValue: true
+      - key: PERSON_HASH_KEY
+        generateValue: true
+      - key: DJANGO_DEBUG
+        value: "0"
+      - key: DJANGO_ALLOWED_HOSTS
+        value: af-jobbansokan.onrender.com
+      - key: DJANGO_CSRF_TRUSTED_ORIGINS
+        value: https://af-jobbansokan.onrender.com
+      - key: BANKID_MOCK
+        value: "1" # demo deployment; set to 0 when real BankID lands
+      - key: DATABASE_URL
+        fromDatabase:
+          name: af-jobbansokan-db
+          property: connectionString
+
+databases:
+  - name: af-jobbansokan-db
+    plan: free

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,10 @@ django-allauth==0.63.6
 djangorestframework_simplejwt==5.5.1
 djangorestframework==3.16.1
 django-unfold==0.97.0
+dj-database-url==3.1.2
 dj-rest-auth==6.0.0
 drf-spectacular==0.29.0
+gunicorn==26.0.0
 idna==3.11
 inflection==0.5.1
 iniconfig==2.3.0
@@ -39,3 +41,4 @@ sqlparse==0.5.5
 tzdata==2025.3
 uritemplate==4.2.0
 urllib3==2.6.3
+whitenoise==6.12.0


### PR DESCRIPTION
## Summary

Everything needed to put the project on a public URL — verified locally end-to-end in production mode (`DEBUG=0` + collectstatic: SPA at `/`, hashed assets, API, admin and security headers all work).

- **One deploy serves everything**: WhiteNoise serves the built frontend at the site root (`WHITENOISE_ROOT` + index file) alongside Django static files with manifest/compressed storage. No CORS, no separate static host
- **Hosted database**: `DATABASE_URL` support via dj-database-url (Render/Heroku style), existing `DB_*` vars still work
- **Security hardening** when `DEBUG=0`: HSTS (1y, preload), SSL redirect behind `X-Forwarded-Proto`, secure cookies, referrer policy, CSRF trusted origins from env
- **Rate limiting**: per-IP throttle on the mock BankID endpoints (`THROTTLE_BANKID`, 10/min) and per-client on the partner API (`THROTTLE_PARTNER`, 120/min) — both env-tunable, with a 429 test
- **Dockerfile** (multi-stage: Node builds the frontend → Python + gunicorn, migrate on boot) and **render.yaml** blueprint: web service + managed Postgres, generated secrets
- **CI**: backend tests now run against **Postgres 16** (same engine as production) instead of SQLite

## Tests

50 passing (new: BankID throttling → 429). Cache cleared between tests so throttle counters stay isolated.

To deploy: push to GitHub → render.com → New → Blueprint → select the repo. The only manual step is creating the Render account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)