### PR TITLE
Add disclosure transparency and CSV export for applicants

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Base path: `/api/v1/` — full interactive docs at `/api/docs/`.
 | `/api/v1/auth/bankid/initiate/` | POST | public | Mock BankID: start order (`BANKID_MOCK=1`) |
 | `/api/v1/auth/bankid/collect/` | POST | public | Mock BankID: complete order, returns JWT |
 | `/api/v1/me/` | GET, PATCH, DELETE | authenticated | Profile incl. identity status; DELETE = GDPR erasure |
+| `/api/v1/me/disclosures/` | GET | applicant | Transparency: who retrieved my data, when, what period |
+| `/api/v1/applications/export/` | GET | applicant | Own events as CSV download |
 | `/api/v1/applications/` | GET, POST | applicant | Own events; filter `?from=&to=&status=` |
 | `/api/v1/applications/{id}/` | GET, DELETE | applicant | **No PUT/PATCH — events are immutable (405)** |
 | `/api/v1/postings/` | GET | public | Paginated list |

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from .models import JobApplication, JobPosting, Organization
+from .models import AuditLog, JobApplication, JobPosting, Organization
 
 User = get_user_model()
 
@@ -117,6 +117,42 @@ class ProfileSerializer(serializers.ModelSerializer):
         if profile is None:
             return None
         return {"organization": profile.organization.name, "role": profile.role}
+
+
+class DisclosureSerializer(serializers.ModelSerializer):
+    """A partner disclosure of the user's own data, for transparency."""
+
+    partner_name = serializers.SerializerMethodField()
+    date_from = serializers.SerializerMethodField()
+    date_to = serializers.SerializerMethodField()
+    application_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AuditLog
+        fields = [
+            "id",
+            "created_at",
+            "partner_name",
+            "date_from",
+            "date_to",
+            "application_count",
+        ]
+
+    @extend_schema_field(serializers.CharField())
+    def get_partner_name(self, obj):
+        return obj.metadata.get("partner_name", "")
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_date_from(self, obj):
+        return obj.metadata.get("date_from")
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_date_to(self, obj):
+        return obj.metadata.get("date_to")
+
+    @extend_schema_field(serializers.IntegerField())
+    def get_application_count(self, obj):
+        return obj.metadata.get("application_count", 0)
 
 
 class PartnerApplicationEventSerializer(serializers.ModelSerializer):

--- a/backend/core/tests/test_transparency.py
+++ b/backend/core/tests/test_transparency.py
@@ -1,0 +1,98 @@
+import pytest
+from core.audit import log_event
+from core.identity import pseudonymize_personal_number
+from core.models import ApplicantProfile, AuditLog, JobApplication
+
+pytestmark = pytest.mark.django_db
+
+DISCLOSURES_URL = "/api/v1/me/disclosures/"
+EXPORT_URL = "/api/v1/applications/export/"
+
+
+@pytest.fixture
+def applicant_identity(applicant):
+    return ApplicantProfile.objects.create(
+        user=applicant,
+        personal_number_hash=pseudonymize_personal_number("199001012384"),
+    )
+
+
+def _log_disclosure(person_hash, partner="A-kassan Alfa", count=2):
+    log_event(
+        None,
+        AuditLog.ACTION_PARTNER_DISCLOSED,
+        partner_client_id=1,
+        partner_name=partner,
+        person_hash=person_hash,
+        date_from="2026-05-01",
+        date_to="2026-06-30",
+        application_count=count,
+    )
+
+
+def test_disclosures_require_auth(api_client):
+    assert api_client.get(DISCLOSURES_URL).status_code == 401
+
+
+def test_user_sees_only_own_disclosures(api_client, applicant, applicant_identity):
+    _log_disclosure(applicant_identity.personal_number_hash)
+    _log_disclosure(pseudonymize_personal_number("200001010000"), partner="Annan")
+
+    api_client.force_authenticate(applicant)
+    body = api_client.get(DISCLOSURES_URL).json()
+    assert body["count"] == 1
+    entry = body["results"][0]
+    assert entry["partner_name"] == "A-kassan Alfa"
+    assert entry["date_from"] == "2026-05-01"
+    assert entry["application_count"] == 2
+
+
+def test_unverified_user_gets_empty_list(api_client, applicant):
+    _log_disclosure(pseudonymize_personal_number("199001012384"))
+    api_client.force_authenticate(applicant)
+    assert api_client.get(DISCLOSURES_URL).json()["count"] == 0
+
+
+def test_export_requires_auth(api_client):
+    assert api_client.get(EXPORT_URL).status_code == 401
+
+
+def test_export_returns_own_applications_as_csv(
+    api_client, applicant, posting, django_user_model
+):
+    other = django_user_model.objects.create_user(username="other", password="x")
+    JobApplication.objects.create(owner=other, posting=posting, applied_at="2026-06-01")
+    JobApplication.objects.create(
+        owner=applicant, posting=posting, applied_at="2026-06-02"
+    )
+
+    api_client.force_authenticate(applicant)
+    response = api_client.get(EXPORT_URL)
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/csv")
+    assert "attachment" in response["Content-Disposition"]
+
+    content = response.content.decode("utf-8-sig")
+    lines = [line for line in content.splitlines() if line]
+    assert len(lines) == 2  # header + one own application
+    assert "2026-06-02" in lines[1]
+    assert posting.title in lines[1]
+
+
+def test_export_applies_date_filters(api_client, applicant, organization):
+    from core.models import JobPosting
+
+    for applied in ["2026-05-01", "2026-06-01"]:
+        JobApplication.objects.create(
+            owner=applicant,
+            posting=JobPosting.objects.create(
+                organization=organization, title=f"Job {applied}", company_name="Acme"
+            ),
+            applied_at=applied,
+        )
+
+    api_client.force_authenticate(applicant)
+    response = api_client.get(EXPORT_URL, {"from": "2026-05-15"})
+    lines = [line for line in response.content.decode("utf-8-sig").splitlines() if line]
+    assert len(lines) == 2
+    assert "2026-06-01" in lines[1]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -7,6 +7,7 @@ from .views import (
     EmployerApplicationsView,
     JobApplicationViewSet,
     JobPostingViewSet,
+    MyDisclosuresView,
     OrganizationCreateView,
     ProfileView,
     partner_application_events,
@@ -18,6 +19,7 @@ router.register(r"postings", JobPostingViewSet, basename="postings")
 
 urlpatterns = [
     path("me/", ProfileView.as_view(), name="me"),
+    path("me/disclosures/", MyDisclosuresView.as_view(), name="my-disclosures"),
     path("", include(router.urls)),
     path(
         "employer/applications/",

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,8 +1,12 @@
+import csv
+
+from django.http import HttpResponse
 from django.utils.dateparse import parse_date
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import generics, mixins, viewsets
 from rest_framework.decorators import (
+    action,
     api_view,
     authentication_classes,
     permission_classes,
@@ -24,6 +28,7 @@ from .models import (
 from .partner_auth import IsPartner, PartnerAPIKeyAuthentication
 from .permissions import IsEmployer, IsEmployerAdminOrReadOnly
 from .serializers import (
+    DisclosureSerializer,
     EmployerApplicationStatusSerializer,
     EmployerJobApplicationSerializer,
     JobApplicationSerializer,
@@ -69,6 +74,29 @@ class ProfileView(generics.RetrieveUpdateDestroyAPIView):
             username=instance.get_username(),
         )
         instance.delete()
+
+
+class MyDisclosuresView(generics.ListAPIView):
+    """Transparency: partner disclosures of the user's own data.
+
+    Matches the audit trail on the user's pseudonymized identity, so it
+    requires a verified (BankID) identity. Users without one have never
+    been disclosed to partners and get an empty list.
+    """
+
+    serializer_class = DisclosureSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):  # schema generation
+            return AuditLog.objects.none()
+        profile = getattr(self.request.user, "applicant_profile", None)
+        if profile is None:
+            return AuditLog.objects.none()
+        return AuditLog.objects.filter(
+            action=AuditLog.ACTION_PARTNER_DISCLOSED,
+            metadata__person_hash=profile.personal_number_hash,
+        ).order_by("-created_at")
 
 
 def _date_param(params, name):
@@ -148,6 +176,31 @@ class JobApplicationViewSet(
             posting_id=instance.posting_id,
         )
         instance.delete()
+
+    @extend_schema(responses={(200, "text/csv"): OpenApiTypes.STR})
+    @action(detail=False, methods=["get"], url_path="export")
+    def export(self, request):
+        """Download own application events as CSV (filters apply)."""
+        qs = self.get_queryset().select_related("posting")
+        response = HttpResponse(content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = 'attachment; filename="ansokningar.csv"'
+        response.write("\ufeff")  # BOM so Excel detects UTF-8
+        writer = csv.writer(response)
+        writer.writerow(
+            ["id", "applied_at", "status", "posting", "company", "created_at"]
+        )
+        for application in qs:
+            writer.writerow(
+                [
+                    application.id,
+                    application.applied_at,
+                    application.status,
+                    application.posting.title,
+                    application.posting.company_name,
+                    application.created_at.isoformat(),
+                ]
+            )
+        return response
 
 
 class JobPostingViewSet(viewsets.ModelViewSet):

--- a/docs/05-api-spec.md
+++ b/docs/05-api-spec.md
@@ -40,6 +40,9 @@
   filterable on applied_at date range and status
 - GET /api/v1/applications/{id}/
 - DELETE /api/v1/applications/{id}/ — audit logged
+- GET /api/v1/applications/export/ — own events as CSV (filters apply)
+- GET /api/v1/me/disclosures/ — transparency: partner disclosures of the
+  user's own data (matched via the pseudonymized identity)
 - Application events are immutable: PUT/PATCH are not allowed (405)
 
 ### Employer

--- a/frontend/src/panels/ApplicantPanel.jsx
+++ b/frontend/src/panels/ApplicantPanel.jsx
@@ -28,8 +28,61 @@ export default function ApplicantPanel() {
         }}
       />
       <MyApplications token={token} />
+      <DisclosuresCard token={token} />
       <Postings token={token} />
     </div>
+  );
+}
+
+function DisclosuresCard({ token }) {
+  const [page, setPage] = useState(null);
+
+  const reload = useCallback(() => {
+    request("/api/v1/me/disclosures/", { token }).then(setPage).catch(() => {});
+  }, [token]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return (
+    <section className="card">
+      <h2>Utlämningar av mina uppgifter</h2>
+      <p className="muted">
+        Insyn: varje gång en A-kassa hämtar dina ansökningshändelser loggas
+        det — här ser du av vem och för vilken period.
+      </p>
+      {page && page.count === 0 && (
+        <p className="muted">Inga utlämningar har skett.</p>
+      )}
+      {page && page.count > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>När</th>
+              <th>Mottagare</th>
+              <th>Period</th>
+              <th>Antal händelser</th>
+            </tr>
+          </thead>
+          <tbody>
+            {page.results.map((d) => (
+              <tr key={d.id}>
+                <td>{new Date(d.created_at).toLocaleString("sv-SE")}</td>
+                <td>{d.partner_name}</td>
+                <td>
+                  {d.date_from || "…"} – {d.date_to || "…"}
+                </td>
+                <td>{d.application_count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <button className="secondary small" onClick={reload}>
+        Uppdatera
+      </button>
+    </section>
   );
 }
 
@@ -215,6 +268,19 @@ function MyApplications({ token }) {
     reload();
   }
 
+  async function exportCsv() {
+    const response = await fetch("/api/v1/applications/export/", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "ansokningar.csv";
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <section className="card">
       <h2>Mina ansökningshändelser</h2>
@@ -226,6 +292,7 @@ function MyApplications({ token }) {
       {applications.length === 0 ? (
         <p className="muted">Inga ansökningar ännu.</p>
       ) : (
+        <>
         <table>
           <thead>
             <tr>
@@ -252,6 +319,10 @@ function MyApplications({ token }) {
             ))}
           </tbody>
         </table>
+        <button className="secondary small" onClick={exportCsv}>
+          Exportera CSV
+        </button>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

The transparency side of the audit trail, plus the last unchecked MVP item.

- **`GET /api/v1/me/disclosures/`** — every partner disclosure of the user's own data: which A-kassa, when, what period, how many records. Matched against the audit trail via the user's pseudonymized identity (JSON key lookup on `person_hash`), so it requires a BankID-verified identity — users without one have never been disclosed and get an empty list
- **`GET /api/v1/applications/export/`** — own application events as a CSV download (UTF-8 BOM so Excel opens it correctly; the existing `from`/`to`/`status` filters apply). Covers the vision's export milestone (CSV; XLSX left as future)
- **Frontend**: an "Utlämningar av mina uppgifter" card and an "Exportera CSV" button in the applicant tab

## Tests

64 passing (6 new): disclosures auth/own-only/unverified-empty, export auth/own-only CSV shape/date filters.

All checks green locally (pytest, ruff, black, schema, frontend build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)