### PR TITLE
Add env-driven bootstrap for shell-less deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=frontend /app/frontend/dist frontend/dist
 RUN python backend/manage.py collectstatic --no-input
 
 EXPOSE 8000
-CMD ["sh", "-c", "python backend/manage.py migrate --no-input && gunicorn config.wsgi:application --chdir backend --bind 0.0.0.0:${PORT:-8000} --workers 2"]
+CMD ["sh", "-c", "python backend/manage.py migrate --no-input && python backend/manage.py bootstrap && gunicorn config.wsgi:application --chdir backend --bind 0.0.0.0:${PORT:-8000} --workers 2"]

--- a/README.md
+++ b/README.md
@@ -237,7 +237,12 @@ host):
   is wired from the database. Deploy via Render → New → Blueprint
 - **Production hardening** activates when `DJANGO_DEBUG=0`: HSTS,
   SSL redirect (behind proxy header), secure cookies, manifest static
-  storage, referrer policy
+  storage, referrer policy. Render's public hostname is trusted
+  automatically via `RENDER_EXTERNAL_HOSTNAME`
+- **Env-driven bootstrap on boot** (free tier has no shell): creates the
+  superuser (`DJANGO_SUPERUSER_USERNAME`/`_PASSWORD`), a partner client
+  (`BOOTSTRAP_PARTNER_NAME`/`_KEY`) and imports postings
+  (`BOOTSTRAP_IMPORT_QUERY`) — all idempotent, all optional
 - **Rate limiting**: mock BankID endpoints are throttled per IP
   (`THROTTLE_BANKID`, default 10/min) and the partner API per client
   (`THROTTLE_PARTNER`, default 120/min)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -170,6 +170,13 @@ CSRF_TRUSTED_ORIGINS = [
     if origin
 ]
 
+# Render injects the public hostname; trust it automatically so the
+# service works even if the subdomain gets a suffix.
+RENDER_HOST = os.getenv("RENDER_EXTERNAL_HOSTNAME")
+if RENDER_HOST:
+    ALLOWED_HOSTS.append(RENDER_HOST)
+    CSRF_TRUSTED_ORIGINS.append(f"https://{RENDER_HOST}")
+
 # Default primary key field type
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/backend/core/management/commands/bootstrap.py
+++ b/backend/core/management/commands/bootstrap.py
@@ -1,0 +1,60 @@
+"""Idempotent production bootstrap, driven entirely by env vars.
+
+Runs on every container start (after migrate) but only acts when the
+corresponding env vars are set and the object does not already exist.
+Needed because Render's free tier has no shell access for one-off
+commands like createsuperuser or create_partner.
+"""
+
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from core.models import JobPosting, PartnerClient
+from core.partner_auth import hash_key
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Idempotent env-driven bootstrap (superuser, partner, postings)."
+
+    def handle(self, *args, **options):
+        self._superuser()
+        self._partner()
+        self._postings()
+
+    def _superuser(self):
+        username = os.getenv("DJANGO_SUPERUSER_USERNAME")
+        password = os.getenv("DJANGO_SUPERUSER_PASSWORD")
+        if not username or not password:
+            return
+        if User.objects.filter(username=username).exists():
+            return
+        User.objects.create_superuser(
+            username, email=os.getenv("DJANGO_SUPERUSER_EMAIL", ""), password=password
+        )
+        self.stdout.write(self.style.SUCCESS(f"Superuser '{username}' created."))
+
+    def _partner(self):
+        name = os.getenv("BOOTSTRAP_PARTNER_NAME")
+        key = os.getenv("BOOTSTRAP_PARTNER_KEY")
+        if not name or not key:
+            return
+        if PartnerClient.objects.filter(name=name).exists():
+            return
+        PartnerClient.objects.create(name=name, key_hash=hash_key(key))
+        self.stdout.write(self.style.SUCCESS(f"Partner '{name}' created."))
+
+    def _postings(self):
+        query = os.getenv("BOOTSTRAP_IMPORT_QUERY")
+        if not query:
+            return
+        if JobPosting.objects.filter(source="jobtech").exists():
+            return
+        try:
+            call_command("import_postings", "--query", query, "--limit", "20")
+        except Exception as exc:  # network hiccup must not block boot
+            self.stderr.write(f"Posting import skipped: {exc}")

--- a/backend/core/tests/test_bootstrap.py
+++ b/backend/core/tests/test_bootstrap.py
@@ -1,0 +1,40 @@
+from io import StringIO
+
+import pytest
+from core.models import PartnerClient
+from core.partner_auth import hash_key
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+def _run():
+    out = StringIO()
+    call_command("bootstrap", stdout=out)
+    return out.getvalue()
+
+
+def test_noop_without_env(api_client):
+    _run()
+    assert not User.objects.filter(is_superuser=True).exists()
+    assert not PartnerClient.objects.exists()
+
+
+def test_creates_superuser_and_partner_idempotently(monkeypatch):
+    monkeypatch.setenv("DJANGO_SUPERUSER_USERNAME", "admin")
+    monkeypatch.setenv("DJANGO_SUPERUSER_PASSWORD", "S3cret!!")
+    monkeypatch.setenv("BOOTSTRAP_PARTNER_NAME", "A-kassan Demo")
+    monkeypatch.setenv("BOOTSTRAP_PARTNER_KEY", "demo-key")
+
+    first = _run()
+    assert "Superuser 'admin' created." in first
+    assert "Partner 'A-kassan Demo' created." in first
+
+    second = _run()  # must not duplicate or crash
+    assert "created" not in second
+    assert User.objects.filter(username="admin", is_superuser=True).count() == 1
+    partner = PartnerClient.objects.get(name="A-kassan Demo")
+    assert partner.key_hash == hash_key("demo-key")

--- a/render.yaml
+++ b/render.yaml
@@ -13,12 +13,21 @@ services:
         generateValue: true
       - key: DJANGO_DEBUG
         value: "0"
-      - key: DJANGO_ALLOWED_HOSTS
-        value: af-jobbansokan.onrender.com
-      - key: DJANGO_CSRF_TRUSTED_ORIGINS
-        value: https://af-jobbansokan.onrender.com
+      # The public hostname is trusted automatically via
+      # RENDER_EXTERNAL_HOSTNAME (set by Render) in settings.py.
       - key: BANKID_MOCK
         value: "1" # demo deployment; set to 0 when real BankID lands
+      # Bootstrap on first boot (idempotent; free tier has no shell):
+      - key: DJANGO_SUPERUSER_USERNAME
+        value: admin
+      - key: DJANGO_SUPERUSER_PASSWORD
+        generateValue: true
+      - key: BOOTSTRAP_PARTNER_NAME
+        value: A-kassan Demo
+      - key: BOOTSTRAP_PARTNER_KEY
+        generateValue: true
+      - key: BOOTSTRAP_IMPORT_QUERY
+        value: utvecklare
       - key: DATABASE_URL
         fromDatabase:
           name: af-jobbansokan-db


### PR DESCRIPTION
## Summary

The last piece before going live on Render's free tier, which has **no shell access** — so one-off commands like `createsuperuser` and `create_partner` must happen automatically.

- **`bootstrap` management command** runs on every container start (after `migrate`), fully idempotent and entirely env-driven:
  - superuser from `DJANGO_SUPERUSER_USERNAME`/`_PASSWORD` (skipped if exists)
  - partner client from `BOOTSTRAP_PARTNER_NAME`/`_KEY` (key supplied, not printed)
  - first-boot posting import from JobTech via `BOOTSTRAP_IMPORT_QUERY` (network failure logs a warning instead of blocking boot)
- **`RENDER_EXTERNAL_HOSTNAME` trusted automatically** in settings — if the onrender.com subdomain gets a suffix, ALLOWED_HOSTS/CSRF still work without manual env fixes
- **render.yaml** generates the superuser password and partner key as secrets (readable in the Render dashboard, never in the repo)

## Tests

78 passing (2 new: bootstrap no-ops without env vars; creates superuser + partner exactly once across repeated runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)