### PR TITLE
Add free text search and filters on postings

### DIFF
--- a/backend/core/tests/test_postings.py
+++ b/backend/core/tests/test_postings.py
@@ -38,6 +38,57 @@ def test_employer_member_cannot_create(api_client, employer_member):
     assert response.status_code == 403
 
 
+def test_search_matches_across_fields(api_client, organization):
+    from core.models import JobPosting
+
+    python_job = JobPosting.objects.create(
+        organization=organization,
+        title="Backendutvecklare",
+        company_name="Acme AB",
+        description="Vi arbetar med Python och Django.",
+        location="Stockholm",
+    )
+    JobPosting.objects.create(
+        organization=organization,
+        title="Frontendutvecklare",
+        company_name="Beta AB",
+        description="React och TypeScript.",
+        location="Göteborg",
+    )
+
+    response = api_client.get(URL, {"search": "python"})
+    assert [p["id"] for p in response.json()["results"]] == [python_job.id]
+
+    # Multiple terms are ANDed together.
+    response = api_client.get(URL, {"search": "python göteborg"})
+    assert response.json()["count"] == 0
+
+
+def test_location_and_source_filters(api_client, organization):
+    from core.models import JobPosting
+
+    stockholm = JobPosting.objects.create(
+        organization=organization,
+        title="A",
+        company_name="X",
+        location="Stockholm",
+        source="jobtech",
+        external_id="j1",
+    )
+    JobPosting.objects.create(
+        organization=organization,
+        title="B",
+        company_name="Y",
+        location="Göteborg",
+    )
+
+    response = api_client.get(URL, {"location": "stockholm"})
+    assert [p["id"] for p in response.json()["results"]] == [stockholm.id]
+
+    response = api_client.get(URL, {"source": "jobtech"})
+    assert [p["id"] for p in response.json()["results"]] == [stockholm.id]
+
+
 def test_employer_admin_creates_for_own_org(api_client, employer_admin, organization):
     api_client.force_authenticate(employer_admin)
     response = api_client.post(

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,5 +1,6 @@
 import csv
 
+from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.dateparse import parse_date
 from drf_spectacular.types import OpenApiTypes
@@ -259,6 +260,23 @@ class JobApplicationViewSet(
         return response
 
 
+@extend_schema_view(
+    list=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                "search",
+                OpenApiTypes.STR,
+                description="Free text over title, company, location and description.",
+            ),
+            OpenApiParameter(
+                "location", OpenApiTypes.STR, description="Filter by location."
+            ),
+            OpenApiParameter(
+                "source", OpenApiTypes.STR, description="Filter by source."
+            ),
+        ]
+    )
+)
 class JobPostingViewSet(viewsets.ModelViewSet):
     serializer_class = JobPostingSerializer
     permission_classes = [IsEmployerAdminOrReadOnly]
@@ -271,8 +289,27 @@ class JobPostingViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         # Public read of all postings (for MVP).
-        # Later we can filter by org, published flag, etc.
-        return JobPosting.objects.all().order_by("-created_at")
+        qs = JobPosting.objects.all().order_by("-created_at")
+        params = self.request.query_params
+
+        # icontains works on SQLite and Postgres alike; upgrade path to
+        # Postgres FTS when volume demands it (docs/09, phase 1).
+        search = params.get("search", "").strip()
+        for term in search.split()[:6]:
+            qs = qs.filter(
+                Q(title__icontains=term)
+                | Q(company_name__icontains=term)
+                | Q(location__icontains=term)
+                | Q(description__icontains=term)
+            )
+
+        location = params.get("location", "").strip()
+        if location:
+            qs = qs.filter(location__icontains=location)
+        source = params.get("source", "").strip()
+        if source:
+            qs = qs.filter(source=source)
+        return qs
 
     def perform_create(self, serializer):
         # Writer must be employer admin -> safe to assume profile exists.

--- a/frontend/src/panels/ApplicantPanel.jsx
+++ b/frontend/src/panels/ApplicantPanel.jsx
@@ -580,10 +580,21 @@ function Postings({ token }) {
   const [url, setUrl] = useState("/api/v1/postings/");
   const [message, setMessage] = useState(null);
   const [selectedId, setSelectedId] = useState(null);
+  const [search, setSearch] = useState("");
+  const [location, setLocation] = useState("");
 
   useEffect(() => {
     request(url).then(setPage).catch((err) => setMessage(err.message));
   }, [url]);
+
+  function applyFilters(event) {
+    event.preventDefault();
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (location.trim()) params.set("location", location.trim());
+    const qs = params.toString();
+    setUrl(`/api/v1/postings/${qs ? `?${qs}` : ""}`);
+  }
 
   async function apply(postingId) {
     setMessage(null);
@@ -609,6 +620,19 @@ function Postings({ token }) {
         Importerade från Arbetsförmedlingens öppna JobTech-API plus
         plattformens egna annonser.
       </p>
+      <form className="searchbar" onSubmit={applyFilters}>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Sök titel, företag eller beskrivning…"
+        />
+        <input
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="Ort"
+        />
+        <button className="small">Sök</button>
+      </form>
       {message && <p className="notice">{message}</p>}
       <table>
         <thead>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -170,6 +170,17 @@ textarea:focus {
   margin-top: 0;
 }
 
+.searchbar {
+  display: grid;
+  grid-template-columns: 3fr 1fr auto;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+.searchbar input {
+  margin-top: 0;
+}
+
 .upload-button {
   display: inline-block;
   margin: 0;


### PR DESCRIPTION
Phase 1 (docs/09): `?search=` over title/company/location/description with ANDed terms, plus `?location=` and `?source=` filters. Search bar in the frontend postings card. 80 tests passing.

?? Generated with [Claude Code](https://claude.com/claude-code)