### PR TITLE
Redesign the frontend with a themeable design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ backend/staticfiles/
 node_modules/
 frontend/dist/
 frontend/.vite/
+frontend/shots/
 
 # IDE
 .vscode/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#4f46e5" />
     <title>AF Jobbansökan</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^5.0.0",
+        "puppeteer-core": "^25.1.0",
         "vite": "^7.1.0"
       }
     },
@@ -790,6 +791,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.4.tgz",
+      "integrity": "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1259,6 +1285,32 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.35",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
@@ -1327,6 +1379,58 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1352,12 +1456,26 @@
         }
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1624250",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz",
+      "integrity": "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.371",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
       "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -1454,6 +1572,26 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1495,6 +1633,23 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ms": {
@@ -1582,6 +1737,24 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/puppeteer-core": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.1.0.tgz",
+      "integrity": "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.4",
+        "chromium-bidi": "16.0.1",
+        "devtools-protocol": "0.0.1624250",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -1607,6 +1780,16 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1684,6 +1867,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1700,6 +1911,13 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -1807,12 +2025,108 @@
         }
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.0",
+    "puppeteer-core": "^25.1.0",
     "vite": "^7.1.0"
   }
 }

--- a/frontend/scripts/screenshots.mjs
+++ b/frontend/scripts/screenshots.mjs
@@ -1,0 +1,76 @@
+// Visual QA: drives the app through real flows and saves screenshots.
+// Usage: node scripts/screenshots.mjs [outdir]   (default: ./shots)
+// Requires the Vite dev server on :5173 and Django on :8000.
+
+import { mkdirSync } from "node:fs";
+import puppeteer from "puppeteer-core";
+
+const OUT = process.argv[2] || "shots";
+const BASE = "http://localhost:5173";
+const EDGE_PATHS = [
+  "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
+  "C:/Program Files/Microsoft/Edge/Application/msedge.exe",
+];
+
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE_PATHS[0],
+  headless: "new",
+  defaultViewport: { width: 1366, height: 1000 },
+});
+
+const page = await browser.newPage();
+const shot = (name) => page.screenshot({ path: `${OUT}/${name}.png` });
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const setTheme = (theme) =>
+  page.evaluate((value) => {
+    localStorage.setItem("theme", value);
+    document.documentElement.dataset.theme = value;
+  }, theme);
+
+await page.goto(BASE, { waitUntil: "networkidle0" });
+await shot("01-login");
+
+// Theme variants of the login view
+for (const theme of ["forest", "dark"]) {
+  await setTheme(theme);
+  await wait(200);
+  await shot(`01-login-${theme}`);
+}
+await setTheme("indigo");
+await wait(200);
+
+// BankID login
+await page.type('input[placeholder="ÅÅÅÅMMDD-NNNN"]', "19900101-2384");
+await page.click("form button");
+await page.waitForSelector("table", { timeout: 10000 }).catch(() => {});
+await wait(800);
+await shot("02-applicant");
+
+// Posting detail modal
+const linklike = await page.$(".linklike");
+if (linklike) {
+  await linklike.click();
+  await page.waitForSelector(".modal", { timeout: 5000 }).catch(() => {});
+  await wait(600);
+  await shot("03-posting-detail");
+  await page.keyboard.press("Escape");
+  const close = await page.$(".modal .secondary");
+  if (close) await close.click();
+  await wait(300);
+}
+
+// Employer tab
+const tabs = await page.$$(".tab");
+await tabs[1].click();
+await wait(400);
+await shot("04-employer-login");
+
+// Partner tab
+await tabs[2].click();
+await wait(400);
+await shot("05-partner");
+
+await browser.close();
+console.log(`Saved screenshots to ${OUT}/`);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import ApplicantPanel from "./panels/ApplicantPanel.jsx";
 import EmployerPanel from "./panels/EmployerPanel.jsx";
@@ -10,15 +10,34 @@ const TABS = [
   { id: "partner", label: "A-kassa (partner)" },
 ];
 
+const THEMES = [
+  { id: "indigo", label: "Indigo" },
+  { id: "forest", label: "Skog" },
+  { id: "dark", label: "Mörk" },
+];
+
 export default function App() {
   const [tab, setTab] = useState("applicant");
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "indigo"
+  );
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   return (
     <div className="app">
       <header className="header">
-        <div>
-          <h1>AF Jobbansökan</h1>
-          <p className="tagline">Verifierbara jobbansökningshändelser — demo</p>
+        <div className="brand">
+          <div className="logo" aria-hidden="true">
+            AF
+          </div>
+          <div>
+            <h1>Jobbansökan</h1>
+            <p className="tagline">Verifierbar · Transparent · Din</p>
+          </div>
         </div>
         <nav className="tabs">
           {TABS.map((t) => (
@@ -42,6 +61,17 @@ export default function App() {
       <footer className="footer">
         Varje skapande, radering och utlämning loggas i en append-only
         auditlogg. Personnummer lagras aldrig i klartext.
+        <div className="theme-picker">
+          {THEMES.map((t) => (
+            <button
+              key={t.id}
+              className={theme === t.id ? "active" : ""}
+              onClick={() => setTheme(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
       </footer>
     </div>
   );

--- a/frontend/src/panels/ApplicantPanel.jsx
+++ b/frontend/src/panels/ApplicantPanel.jsx
@@ -8,12 +8,32 @@ export default function ApplicantPanel() {
 
   if (!token) {
     return (
-      <BankIDLogin
-        onLogin={async (access) => {
-          setToken(access);
-          setMe(await request("/api/v1/me/", { token: access }));
-        }}
-      />
+      <div className="hero">
+        <div className="hero-copy">
+          <span className="eyebrow">Förtroende som grundfunktion</span>
+          <h2>
+            Sök jobb. Bevisa det.
+            <br />
+            <span className="grad">Äg din egen data.</span>
+          </h2>
+          <p className="lede">
+            Hela svenska annonsmarknaden, en BankID-verifierad profil och en
+            ansökningshistorik som ingen kan manipulera — inte ens vi.
+          </p>
+          <ul className="checklist">
+            <li>BankID-verifierad identitet, pseudonymiserad lagring</li>
+            <li>Oföränderliga ansökningshändelser med full auditlogg</li>
+            <li>Se exakt vem som tagit del av dina uppgifter, och när</li>
+            <li>CV som matchas mot varje annons — helt förklarbart</li>
+          </ul>
+        </div>
+        <BankIDLogin
+          onLogin={async (access) => {
+            setToken(access);
+            setMe(await request("/api/v1/me/", { token: access }));
+          }}
+        />
+      </div>
     );
   }
   return (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,99 +1,347 @@
 :root {
-  --blue: #1616b2;
-  --blue-dark: #0d0d6b;
-  --bg: #f4f5f7;
-  --card: #ffffff;
-  --text: #1a1a2e;
-  --muted: #6b7280;
-  --border: #e3e5e8;
+  --brand: #4f46e5;
+  --brand-2: #7c3aed;
+  --brand-ink: #312e81;
+  --brand-glow-1: rgba(124, 58, 237, 0.09);
+  --brand-glow-2: rgba(79, 70, 229, 0.08);
+  --bg: #f5f6fa;
+  --bg-translucent: rgba(245, 246, 250, 0.82);
+  --surface: #ffffff;
+  --surface-2: #fafafd;
+  --hover: #f7f7fc;
+  --ink: #16161f;
+  --muted: #676d7c;
+  --label: #3c3f4a;
+  --border: #e6e8ef;
+  --input-border: #d8dbe5;
+  --chip: #eef0fb;
+  --chip-ink: #312e81;
+  --accent-soft: #f4f3ff;
+  --accent-border: #d4d2f5;
   --green: #0f7b3e;
+  --green-bg: #e4f5eb;
+  --green-border: #cdebd9;
   --red: #b91c1c;
+  --red-bg: #fdeaea;
+  --red-border: #f5d5d5;
   --amber: #92600a;
+  --amber-bg: #fdf3e0;
+  --star: #d9a514;
+  --radius: 16px;
+  --radius-sm: 10px;
+  --shadow-sm: 0 1px 2px rgba(22, 22, 31, 0.05), 0 1px 6px rgba(22, 22, 31, 0.04);
+  --shadow-md: 0 4px 16px rgba(22, 22, 31, 0.08), 0 1px 4px rgba(22, 22, 31, 0.05);
+  --shadow-lg: 0 24px 60px rgba(22, 22, 31, 0.22);
+  --button-glow: rgba(79, 70, 229, 0.28);
+  --grad: linear-gradient(120deg, var(--brand), var(--brand-2));
+}
+
+[data-theme="forest"] {
+  --brand: #0f766e;
+  --brand-2: #15803d;
+  --brand-ink: #134e4a;
+  --brand-glow-1: rgba(21, 128, 61, 0.1);
+  --brand-glow-2: rgba(15, 118, 110, 0.09);
+  --chip: #e7f2ef;
+  --chip-ink: #134e4a;
+  --accent-soft: #effaf5;
+  --accent-border: #bfe3d5;
+  --button-glow: rgba(15, 118, 110, 0.28);
+}
+
+[data-theme="dark"] {
+  --brand: #818cf8;
+  --brand-2: #a78bfa;
+  --brand-ink: #c7d2fe;
+  --brand-glow-1: rgba(167, 139, 250, 0.1);
+  --brand-glow-2: rgba(129, 140, 248, 0.08);
+  --bg: #0f1016;
+  --bg-translucent: rgba(15, 16, 22, 0.8);
+  --surface: #181a24;
+  --surface-2: #1d2030;
+  --hover: #21243266;
+  --ink: #ecedf3;
+  --muted: #9aa0af;
+  --label: #c2c6d1;
+  --border: #292c3b;
+  --input-border: #363a4d;
+  --chip: #272b40;
+  --chip-ink: #c7d2fe;
+  --accent-soft: #232743;
+  --accent-border: #3b3f63;
+  --green: #4ade80;
+  --green-bg: #14291d;
+  --green-border: #1f4030;
+  --red: #f87171;
+  --red-bg: #2d1717;
+  --red-border: #4a2222;
+  --amber: #fbbf24;
+  --amber-bg: #2b2110;
+  --star: #fbbf24;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 18px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.7);
+  --button-glow: rgba(129, 140, 248, 0.25);
 }
 
 * {
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
+html {
+  background: var(--bg);
+}
+
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  background: var(--bg);
-  color: var(--text);
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  background:
+    radial-gradient(1200px 760px at 85% -12%, var(--brand-glow-1), transparent 72%),
+    radial-gradient(1000px 640px at -12% 10%, var(--brand-glow-2), transparent 68%),
+    var(--bg);
+  background-repeat: no-repeat;
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
 }
 
 .app {
-  max-width: 1000px;
+  max-width: 1060px;
   margin: 0 auto;
-  padding: 0 1.25rem 3rem;
+  padding: 0 1.5rem 4rem;
 }
 
+/* ---------- Header ---------- */
+
 .header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 2rem 0 1rem;
-  border-bottom: 3px solid var(--blue);
-  margin-bottom: 1.5rem;
+  padding: 0.9rem 0;
+  margin-bottom: 1.75rem;
+  background: var(--bg-translucent);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.logo {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: var(--grad);
+  color: #fff;
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.35);
 }
 
 .header h1 {
   margin: 0;
-  font-size: 1.6rem;
-  color: var(--blue-dark);
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
 }
 
 .tagline {
-  margin: 0.25rem 0 0;
+  margin: 0;
   color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 600;
 }
 
 .tabs {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.3rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .tab {
   background: none;
-  border: 1px solid var(--border);
-  border-radius: 8px 8px 0 0;
-  padding: 0.6rem 1.1rem;
-  font-size: 0.95rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
   cursor: pointer;
   color: var(--muted);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.tab:hover {
+  color: var(--ink);
+  background: var(--hover);
 }
 
 .tab.active {
-  background: var(--blue);
-  border-color: var(--blue);
+  background: var(--grad);
   color: #fff;
-  font-weight: 600;
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.35);
 }
+
+/* ---------- Hero ---------- */
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 3rem;
+  align-items: center;
+  padding: 2.5rem 0 1rem;
+}
+
+@media (max-width: 880px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--brand);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  margin-bottom: 1.1rem;
+}
+
+.hero h2 {
+  margin: 0 0 1rem;
+  font-size: 2.6rem;
+  line-height: 1.12;
+  font-weight: 800;
+  letter-spacing: -0.035em;
+}
+
+.grad {
+  background: var(--grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lede {
+  font-size: 1.05rem;
+  color: var(--muted);
+  margin: 0 0 1.4rem;
+  max-width: 46ch;
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.checklist li {
+  padding-left: 1.9rem;
+  position: relative;
+  font-weight: 500;
+}
+
+.checklist li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1.3rem;
+  height: 1.3rem;
+  border-radius: 50%;
+  background: var(--green-bg);
+  color: var(--green);
+  font-size: 0.8rem;
+  font-weight: 800;
+  display: grid;
+  place-items: center;
+}
+
+/* ---------- Cards ---------- */
 
 .stack {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.4rem;
 }
 
 .card {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  border-radius: var(--radius);
+  padding: 1.5rem 1.75rem;
+  box-shadow: var(--shadow-sm);
+  animation: rise 0.35s ease both;
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .card.narrow {
-  max-width: 440px;
-  margin: 2rem auto;
+  max-width: 430px;
+  width: 100%;
+  margin: 0 auto;
+  box-shadow: var(--shadow-md);
+}
+
+.hero .card.narrow {
+  margin: 0;
+  justify-self: end;
 }
 
 .card h2 {
-  margin: 0 0 0.25rem;
+  margin: 0 0 0.3rem;
   font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.card h3 {
+  margin: 1.4rem 0 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
 }
 
 .row-between {
@@ -101,243 +349,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-}
-
-.muted {
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-label {
-  display: block;
-  margin: 0.75rem 0;
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-input {
-  display: block;
-  width: 100%;
-  margin-top: 0.3rem;
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 0.95rem;
-  font-weight: 400;
-}
-
-input:focus {
-  outline: 2px solid var(--blue);
-  border-color: var(--blue);
-}
-
-select {
-  padding: 0.35rem 0.5rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 0.9rem;
-  background: #fff;
-}
-
-textarea {
-  display: block;
-  width: 100%;
-  margin-top: 0.3rem;
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 0.95rem;
-  font-weight: 400;
-  font-family: inherit;
-  min-height: 4.5rem;
-  resize: vertical;
-}
-
-textarea:focus {
-  outline: 2px solid var(--blue);
-  border-color: var(--blue);
-}
-
-.rowline {
-  display: grid;
-  grid-template-columns: 2fr 2fr 1fr auto;
-  gap: 0.5rem;
-  align-items: start;
-  margin-bottom: 0.4rem;
-}
-
-.rowline input {
-  margin-top: 0;
-}
-
-.star {
-  background: none;
-  border: none;
-  font-size: 1.1rem;
-  color: var(--amber);
-  cursor: pointer;
-  padding: 0 0.2rem;
-}
-
-.star:hover {
-  background: none;
-  transform: scale(1.2);
-}
-
-.searchbar {
-  display: grid;
-  grid-template-columns: 3fr 1fr auto;
-  gap: 0.5rem;
-  margin: 0.5rem 0 0.75rem;
-}
-
-.searchbar input {
-  margin-top: 0;
-}
-
-.upload-button {
-  display: inline-block;
-  margin: 0;
-  padding: 0.35rem 0.8rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--blue);
-  background: #fff;
-  border: 1px solid var(--blue);
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.upload-button:hover {
-  background: #eef;
-}
-
-button {
-  background: var(--blue);
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  padding: 0.6rem 1.2rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-button:hover {
-  background: var(--blue-dark);
-}
-
-button:disabled {
-  opacity: 0.6;
-  cursor: wait;
-}
-
-button.secondary {
-  background: #fff;
-  color: var(--blue);
-  border: 1px solid var(--blue);
-}
-
-button.secondary:hover {
-  background: #eef;
-}
-
-button.secondary:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-button.danger {
-  background: #fff;
-  color: var(--red);
-  border: 1px solid var(--red);
-}
-
-button.danger:hover {
-  background: #fef2f2;
-}
-
-button.small {
-  padding: 0.35rem 0.8rem;
-  font-size: 0.85rem;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0.75rem 0;
-}
-
-th,
-td {
-  text-align: left;
-  padding: 0.55rem 0.6rem;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.92rem;
-}
-
-th {
-  color: var(--muted);
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.badge {
-  display: inline-block;
-  padding: 0.15rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  background: #eef;
-  color: var(--blue-dark);
-}
-
-.badge.applied {
-  background: #e7f4ec;
-  color: var(--green);
-}
-
-.badge.interview {
-  background: #fdf3e0;
-  color: var(--amber);
-}
-
-.badge.rejected {
-  background: #fde8e8;
-  color: var(--red);
-}
-
-.badge.neutral {
-  background: #f0f1f3;
-  color: var(--muted);
-}
-
-.error {
-  color: var(--red);
-  background: #fde8e8;
-  border-radius: 6px;
-  padding: 0.5rem 0.8rem;
-  font-size: 0.9rem;
-}
-
-.notice {
-  color: var(--green);
-  background: #e7f4ec;
-  border-radius: 6px;
-  padding: 0.5rem 0.8rem;
-  font-size: 0.9rem;
-}
-
-.grid3 {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0 1rem;
-}
-
-.pager {
-  display: flex;
-  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .row-gap {
@@ -346,68 +358,425 @@ th {
   align-items: flex-start;
 }
 
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+/* ---------- Forms ---------- */
+
+label {
+  display: block;
+  margin: 0.85rem 0;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--label);
+}
+
+input,
+textarea,
+select {
+  display: block;
+  width: 100%;
+  margin-top: 0.35rem;
+  padding: 0.62rem 0.85rem;
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  font-weight: 400;
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--ink);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--button-glow);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--muted);
+  opacity: 0.7;
+}
+
+textarea {
+  min-height: 4.5rem;
+  resize: vertical;
+}
+
+select {
+  width: auto;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+/* ---------- Buttons ---------- */
+
+button {
+  background: var(--grad);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.62rem 1.3rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.15s ease, filter 0.15s ease;
+  box-shadow: 0 3px 12px var(--button-glow);
+}
+
+button:hover {
+  filter: brightness(1.07);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px var(--button-glow);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+  transform: none;
+}
+
+button.secondary {
+  background: var(--surface);
+  color: var(--brand);
+  border: 1px solid var(--accent-border);
+  box-shadow: none;
+}
+
+button.secondary:hover {
+  background: var(--accent-soft);
+  filter: none;
+  box-shadow: none;
+  transform: none;
+}
+
+button.secondary:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+button.danger {
+  background: var(--surface);
+  color: var(--red);
+  border: 1px solid var(--red-border);
+  box-shadow: none;
+}
+
+button.danger:hover {
+  background: var(--red-bg);
+  filter: none;
+  box-shadow: none;
+  transform: none;
+}
+
+button.small {
+  padding: 0.38rem 0.85rem;
+  font-size: 0.84rem;
+  border-radius: 8px;
+}
+
 .linklike {
   background: none;
   border: none;
-  color: var(--blue);
+  color: var(--brand);
   padding: 0;
   font-size: 0.92rem;
   font-weight: 600;
   text-align: left;
   cursor: pointer;
-  text-decoration: underline;
+  text-decoration: none;
+  box-shadow: none;
 }
 
 .linklike:hover {
+  text-decoration: underline;
   background: none;
-  color: var(--blue-dark);
+  transform: none;
+  filter: none;
+  box-shadow: none;
+  color: var(--brand-ink);
 }
+
+.star {
+  background: none;
+  border: none;
+  font-size: 1.15rem;
+  color: var(--star);
+  cursor: pointer;
+  padding: 0 0.2rem;
+  box-shadow: none;
+  transition: transform 0.12s ease;
+}
+
+.star:hover {
+  background: none;
+  transform: scale(1.25);
+  filter: none;
+  box-shadow: none;
+}
+
+.upload-button {
+  display: inline-block;
+  margin: 0;
+  padding: 0.38rem 0.85rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--brand);
+  background: var(--surface);
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.upload-button:hover {
+  background: var(--accent-soft);
+}
+
+/* ---------- Tables ---------- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.9rem 0;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.65rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.91rem;
+}
+
+th {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-weight: 700;
+}
+
+tbody tr {
+  transition: background 0.12s ease;
+}
+
+tbody tr:hover {
+  background: var(--hover);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* ---------- Badges & alerts ---------- */
+
+.badge {
+  display: inline-block;
+  padding: 0.18rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  background: var(--chip);
+  color: var(--chip-ink);
+  margin: 0 0.15rem 0.15rem 0;
+}
+
+.badge.applied {
+  background: var(--green-bg);
+  color: var(--green);
+}
+
+.badge.interview {
+  background: var(--amber-bg);
+  color: var(--amber);
+}
+
+.badge.rejected {
+  background: var(--red-bg);
+  color: var(--red);
+}
+
+.badge.neutral {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+.error {
+  color: var(--red);
+  background: var(--red-bg);
+  border: 1px solid var(--red-border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.notice {
+  color: var(--green);
+  background: var(--green-bg);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+/* ---------- Layout helpers ---------- */
+
+.grid3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0 1rem;
+}
+
+.rowline {
+  display: grid;
+  grid-template-columns: 2fr 2fr 1fr auto;
+  gap: 0.5rem;
+  align-items: start;
+  margin-bottom: 0.45rem;
+}
+
+.rowline input {
+  margin-top: 0;
+}
+
+.searchbar {
+  display: grid;
+  grid-template-columns: 3fr 1fr auto;
+  gap: 0.5rem;
+  margin: 0.6rem 0 0.9rem;
+}
+
+.searchbar input {
+  margin-top: 0;
+}
+
+.pager {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ---------- Modal ---------- */
 
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(10, 10, 40, 0.45);
+  background: rgba(18, 16, 38, 0.5);
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
-  z-index: 10;
+  z-index: 50;
+  animation: fade 0.18s ease both;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .modal {
-  background: var(--card);
-  border-radius: 10px;
-  padding: 1.5rem 1.75rem;
-  max-width: 720px;
+  background: var(--surface);
+  border-radius: 20px;
+  padding: 1.75rem 2rem;
+  max-width: 760px;
   width: 100%;
-  max-height: 85vh;
+  max-height: 86vh;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
+  box-shadow: var(--shadow-lg);
+  animation: pop 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.2) both;
+}
+
+@keyframes pop {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .description {
   white-space: pre-wrap;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.9rem 1.1rem;
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
   font-size: 0.92rem;
-  line-height: 1.55;
-  background: #fafbfc;
+  line-height: 1.6;
+  background: var(--surface-2);
 }
 
+/* ---------- Footer ---------- */
+
 .footer {
-  margin-top: 2.5rem;
-  padding-top: 1rem;
+  margin-top: 3rem;
+  padding-top: 1.25rem;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: 0.84rem;
+  text-align: center;
 }
 
 code {
-  background: #f0f1f3;
-  padding: 0.1rem 0.35rem;
-  border-radius: 4px;
-  font-size: 0.88em;
+  background: var(--chip);
+  color: var(--chip-ink);
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.86em;
+}
+
+.theme-picker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 0.9rem;
+}
+
+.theme-picker button {
+  background: var(--surface);
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.theme-picker button:hover {
+  color: var(--ink);
+  filter: none;
+  transform: none;
+  box-shadow: none;
+}
+
+.theme-picker button.active {
+  background: var(--grad);
+  color: #fff;
+  border-color: transparent;
 }


### PR DESCRIPTION
## Summary

Full visual overhaul built on CSS design tokens, verified screenshot-by-screenshot with a new visual QA script.

- **Three themes** with a footer picker (persisted in localStorage): **Indigo** (default), **Skog** (emerald) and **Mörk** (dark mode) — every color in the system is a variable, so themes are ~30 lines each
- **Look**: Inter typography, sticky glass header (backdrop blur) with gradient logo mark and pill-shaped tabs, hero section on the login view with value-proposition checklist, gradient primary buttons with hover lift, soft cards with entrance animation, modal with backdrop blur + pop-in, refined tables/badges/forms
- **Bug fixes found during visual QA**: the hidden file input in the CV card was visible (`input { display: block }` overrode the `hidden` attribute — fixed with `[hidden] { display: none !important }`), and background gradient banding on short pages
- **`frontend/scripts/screenshots.mjs`** (puppeteer-core driving Edge): logs in via mock BankID, walks all tabs and themes, saves screenshots — the tool used to iterate on this PR, committed for future visual work

No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)