### PR TITLE
Add scheduled jobs workflow for cron tasks

### DIFF
--- a/.github/workflows/scheduled-jobs.yml
+++ b/.github/workflows/scheduled-jobs.yml
@@ -1,0 +1,61 @@
+name: Scheduled jobs
+
+# Ersatter Render cron jobs: ansokt-reminders, ansokt-prune, ansokt-weekly-summary.
+on:
+  schedule:
+    - cron: "0 6 * * *"
+    - cron: "15 6 * * *"
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      command:
+        description: Kommando att kora manuellt
+        required: true
+        type: choice
+        options:
+          - send_reminders
+          - prune_inactive_accounts
+          - send_weekly_summary
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - run: pip install -r requirements.txt
+      - name: Run management command
+        env:
+          PYTHONPATH: backend
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DJANGO_SETTINGS_MODULE: config.settings
+          DJANGO_DEBUG: "0"
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
+          EMAIL_PORT: "587"
+          EMAIL_HOST_USER: ${{ secrets.EMAIL_HOST_USER }}
+          EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
+          EMAIL_USE_TLS: "1"
+          EMAIL_USE_SSL: "0"
+          EMAIL_TIMEOUT: "10"
+          DEFAULT_FROM_EMAIL: ${{ secrets.DEFAULT_FROM_EMAIL }}
+          BREVO_API_KEY: ${{ secrets.BREVO_API_KEY }}
+          CONTACT_EMAIL: ${{ secrets.CONTACT_EMAIL }}
+          FRONTEND_URL: https://jobbjungeln.onrender.com
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: production
+          SCHEDULE: ${{ github.event.schedule }}
+          MANUAL: ${{ inputs.command }}
+        run: |
+          case "$SCHEDULE" in
+            "0 6 * * *")  CMD=send_reminders ;;
+            "15 6 * * *") CMD=prune_inactive_accounts ;;
+            "0 7 * * 1")  CMD=send_weekly_summary ;;
+            *)            CMD="$MANUAL" ;;
+          esac
+          echo "Kor: $CMD"
+          python backend/manage.py "$CMD"


### PR DESCRIPTION
Flyttar de tre Render-cronjobben till GitHub Actions (gratis): 0 6 * * * = send_reminders (ansokt-reminders), 15 6 * * * = prune_inactive_accounts (ansokt-prune), 0 7 * * 1 = send_weekly_summary (ansokt-weekly-summary). Kan aven koras manuellt via workflow_dispatch.

Kraver repo-secrets: DATABASE_URL (Supabase pooler-URL), DJANGO_SECRET_KEY, EMAIL_HOST, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD, DEFAULT_FROM_EMAIL, BREVO_API_KEY, CONTACT_EMAIL, SENTRY_DSN. Efter merge: ta bort cron-blocken i render.yaml och radera de tre cron-tjansterna i Render.